### PR TITLE
README: link for custom firmware source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ All files from table are already encoded and can be directly flashed using firmw
 
 
 # Links
-* ![New_Logo](https://github.com/amnemonic/Quansheng_UV-K5_Firmware/assets/29899901/9b6b8303-6a95-4c9f-81b7-52782500f833) [On-line firmware modder by @whosmatt](https://whosmatt.github.io/uvmod/) ![new3](https://github.com/amnemonic/Quansheng_UV-K5_Firmware/assets/29899901/4815527c-508c-4d93-9c33-149d1ebd6234)
+* ![New_Logo](https://github.com/amnemonic/Quansheng_UV-K5_Firmware/assets/29899901/9b6b8303-6a95-4c9f-81b7-52782500f833) [Custom open source firmware by OneOfEleven ](https://github.com/OneOfEleven/uv-k5-firmware-custom)
+* [On-line firmware modder by @whosmatt](https://whosmatt.github.io/uvmod/)⭐
 * [ludwich66 - Quansheng UV-K5 Wiki](https://github.com/ludwich66/Quansheng_UV-K5_Wiki/wiki)
 * [Tunas1337 - UV-K5-Modded-Firmwares](https://github.com/Tunas1337/UV-K5-Modded-Firmwares)
 * [sq5bpf - uvk5-reverse-engineering](https://github.com/sq5bpf/uvk5-reverse-engineering) | [CHIRP Driver](https://github.com/sq5bpf/uvk5-reverse-engineering/blob/main/uvk5.py) | [Official CHIRP Driver](https://github.com/kk7ds/chirp/blob/master/chirp/drivers/uvk5.py)


### PR DESCRIPTION
Custom firmware with full source code was released.
The original repository is: https://github.com/DualTachyon/uv-k5-firmware
The one that I added contains additional AM receiving fix that I consider important.