### PR TITLE
Fixed filename

### DIFF
--- a/uvmod_kitchen_31/build.sh
+++ b/uvmod_kitchen_31/build.sh
@@ -3,7 +3,7 @@
 rm -rf temp 2>/dev/null
 mkdir temp
 
-python3 qsfirm.py unpack k5_v2.01.26_publish.bin temp/fw.dec.bin temp/fw.ver.bin
+python3 qsfirm.py unpack k5_v2.01.31_publish.bin temp/fw.dec.bin temp/fw.ver.bin
 
 # here comment or uncomment mods
 
@@ -14,4 +14,4 @@ python3 mod_universal_version.py  temp/fw.ver.bin
 
 # end of mods
 
-python3 qsfirm.py pack temp/fw.dec.bin temp/fw.ver.bin k5_v2.01.26_MODDED.bin
+python3 qsfirm.py pack temp/fw.dec.bin temp/fw.ver.bin k5_v2.01.31_MODDED.bin


### PR DESCRIPTION
The file name of an old firmware version was used in the build script. I changed this from v2.01.26 to v2.01.31.